### PR TITLE
feat: Colored theme reactive tray icons for MacOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2653,6 +2653,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5906f93257178e2f7ae069efb89fbd6ee94f0592740b5f8a1512ca498814d0fb"
 dependencies = [
  "bitflags 2.8.0",
+ "block2 0.6.1",
  "objc2 0.6.1",
  "objc2-core-foundation",
  "objc2-foundation 0.3.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -559,11 +559,11 @@ dependencies = [
 
 [[package]]
 name = "block2"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d59b4c170e16f0405a2e95aff44432a0d41aa97675f3d52623effe95792a037"
+checksum = "340d2f0bdb2a43c1d3cd40513185b2bd7def0aa1052f956455114bc98f82dcf2"
 dependencies = [
- "objc2 0.6.0",
+ "objc2 0.6.1",
 ]
 
 [[package]]
@@ -2412,7 +2412,7 @@ dependencies = [
  "gtk",
  "keyboard-types",
  "libxdo",
- "objc2 0.6.0",
+ "objc2 0.6.1",
  "objc2-app-kit 0.3.0",
  "objc2-core-foundation",
  "objc2-foundation 0.3.0",
@@ -2623,9 +2623,9 @@ dependencies = [
 
 [[package]]
 name = "objc2"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3531f65190d9cff863b77a99857e74c314dd16bf56c538c4b57c7cbc3f3a6e59"
+checksum = "88c6597e14493ab2e44ce58f2fdecf095a51f12ca57bec060a11c57332520551"
 dependencies = [
  "objc2-encode",
 ]
@@ -2653,7 +2653,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5906f93257178e2f7ae069efb89fbd6ee94f0592740b5f8a1512ca498814d0fb"
 dependencies = [
  "bitflags 2.8.0",
- "objc2 0.6.0",
+ "objc2 0.6.1",
  "objc2-core-foundation",
  "objc2-foundation 0.3.0",
 ]
@@ -2701,7 +2701,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daeaf60f25471d26948a1c2f840e3f7d86f4109e3af4e8e4b5cd70c39690d925"
 dependencies = [
  "bitflags 2.8.0",
- "objc2 0.6.0",
+ "objc2 0.6.1",
 ]
 
 [[package]]
@@ -2764,8 +2764,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a21c6c9014b82c39515db5b396f91645182611c97d24637cf56ac01e5f8d998"
 dependencies = [
  "bitflags 2.8.0",
- "block2 0.6.0",
- "objc2 0.6.0",
+ "block2 0.6.1",
+ "objc2 0.6.1",
  "objc2-core-foundation",
 ]
 
@@ -3691,7 +3691,7 @@ dependencies = [
  "ndk",
  "ndk-context",
  "ndk-sys 0.6.0+11769913",
- "objc2 0.6.0",
+ "objc2 0.6.1",
  "objc2-app-kit 0.3.0",
  "objc2-foundation 0.3.0",
  "once_cell",
@@ -3924,6 +3924,7 @@ dependencies = [
 name = "tray-icon"
 version = "0.21.0"
 dependencies = [
+ "block2 0.6.1",
  "crossbeam-channel",
  "dirs",
  "eframe",
@@ -3931,7 +3932,7 @@ dependencies = [
  "image",
  "libappindicator",
  "muda",
- "objc2 0.6.0",
+ "objc2 0.6.1",
  "objc2-app-kit 0.3.0",
  "objc2-core-foundation",
  "objc2-core-graphics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,7 @@ objc2-app-kit = { version = "0.3", default-features = false, features = [
   "NSView",
   "NSWindow",
 ] }
+block2 = "0.6"
 
 [target."cfg(any(target_os = \"linux\", target_os = \"macos\"))".dependencies]
 png = "0.17"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ objc2-foundation = { version = "0.3", default-features = false, features = [
   "NSThread",
 ] }
 objc2-app-kit = { version = "0.3", default-features = false, features = [
+  "block2",
   "std",
   "objc2-core-foundation",
   "NSButton",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ objc2-app-kit = { version = "0.3", default-features = false, features = [
   "block2",
   "std",
   "objc2-core-foundation",
+  "NSAppearance",
   "NSButton",
   "NSCell",
   "NSControl",

--- a/README.md
+++ b/README.md
@@ -61,6 +61,22 @@ let tray_icon = TrayIconBuilder::new()
     .unwrap();
 ```
 
+#### Create a tray icon that reacts to the menu bar theme **macOS only**
+
+```rs
+use tray_icon::TrayIconBuilder;
+
+let tray_icon = TrayIconBuilder::new()
+    .with_tooltip("themed tray icon!")
+    // if your icon is grayscale, enable template mode
+    //.with_icon(icon).with_template(true)
+
+    // ...otherwise set a different icon for light and dark themes
+    .with_themed_icon(light_icon, dark_icon)
+    .build()
+    .unwrap();
+```
+
 ## Processing tray events
 
 You can use `TrayIconEvent::receiver` to get a reference to the `TrayIconEventReceiver`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -370,6 +370,10 @@ impl TrayIcon {
         self.tray.borrow_mut().set_icon(icon)
     }
 
+    pub fn set_themed_icon(&self, light_icon: Icon, dark_icon: Icon) -> Result<()> {
+        self.tray.borrow_mut().set_themed_icon(light_icon, dark_icon)
+    }
+
     /// Set new tray menu.
     ///
     /// ## Platform-specific:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -374,7 +374,9 @@ impl TrayIcon {
     /// and the dark icon is used when the taskbar is light.
     #[cfg(target_os = "macos")]
     pub fn set_themed_icon(&self, light_icon: Icon, dark_icon: Icon) -> Result<()> {
-        self.tray.borrow_mut().set_themed_icon(light_icon, dark_icon)
+        self.tray
+            .borrow_mut()
+            .set_themed_icon(light_icon, dark_icon)
     }
 
     /// Set new tray menu.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -370,6 +370,9 @@ impl TrayIcon {
         self.tray.borrow_mut().set_icon(icon)
     }
 
+    /// Set a new themed tray icon. The light icon is used when the taskbar is dark
+    /// and the dark icon is used when the taskbar is light.
+    #[cfg(target_os = "macos")]
     pub fn set_themed_icon(&self, light_icon: Icon, dark_icon: Icon) -> Result<()> {
         self.tray.borrow_mut().set_themed_icon(light_icon, dark_icon)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,6 +172,9 @@ pub struct TrayIconAttributes {
     ///   Setting an empty [`Menu`](crate::menu::Menu) is enough.
     pub icon: Option<Icon>,
 
+    /// Dark theme tray icon. **macOS only**.
+    pub dark_icon: Option<Icon>,
+
     /// Tray icon temp dir path. **Linux only**.
     pub temp_dir_path: Option<PathBuf>,
 
@@ -204,6 +207,7 @@ impl Default for TrayIconAttributes {
             tooltip: None,
             menu: None,
             icon: None,
+            dark_icon: None,
             temp_dir_path: None,
             icon_is_template: false,
             menu_on_left_click: true,
@@ -254,6 +258,16 @@ impl TrayIconBuilder {
     ///   Setting an empty [`Menu`](crate::menu::Menu) is enough.
     pub fn with_icon(mut self, icon: Icon) -> Self {
         self.attrs.icon = Some(icon);
+        self
+    }
+
+    /// Automatically set appropriate icon based on the menu bar theme. **macOS only**
+    ///
+    /// The light icon will be used when the menu bar is dark and vice versa.
+    /// If the icon doesn't have color, see [`with_icon_as_template`](Self::with_icon_as_template).
+    pub fn with_themed_icon(mut self, light_icon: Icon, dark_icon: Icon) -> Self {
+        self.attrs.icon = Some(light_icon);
+        self.attrs.dark_icon = Some(dark_icon);
         self
     }
 
@@ -370,13 +384,23 @@ impl TrayIcon {
         self.tray.borrow_mut().set_icon(icon)
     }
 
-    /// Set a new themed tray icon. The light icon is used when the taskbar is dark
-    /// and the dark icon is used when the taskbar is light.
-    #[cfg(target_os = "macos")]
+    /// Automatically set appropriate icon based on the menu bar theme. **macOS only**
+    ///
+    /// The light icon will be used when the menu bar is dark and vice versa.
+    /// If the icon doesn't have color, see [`set_icon_as_template`](Self::set_icon_as_template).
     pub fn set_themed_icon(&self, light_icon: Icon, dark_icon: Icon) -> Result<()> {
-        self.tray
+        #[cfg(target_os = "macos")]
+        return self
+            .tray
             .borrow_mut()
-            .set_themed_icon(light_icon, dark_icon)
+            .set_themed_icon(light_icon, dark_icon);
+
+        #[cfg(not(target_os = "macos"))]
+        {
+            let _ = light_icon;
+            let _ = dark_icon;
+            Ok(())
+        }
     }
 
     /// Set new tray menu.

--- a/src/platform_impl/macos/mod.rs
+++ b/src/platform_impl/macos/mod.rs
@@ -5,8 +5,7 @@
 mod icon;
 use std::cell::{Cell, RefCell};
 
-use block2::{Block, RcBlock};
-use objc2::ffi::id;
+use block2::RcBlock;
 use objc2::rc::Retained;
 use objc2::runtime::{self, AnyObject};
 use objc2::{class, define_class, msg_send, sel, AllocAnyThread, DeclaredClass, Message};
@@ -333,7 +332,6 @@ fn set_themed_icon_for_ns_status_item_button(
         let dark_nsdata = NSData::from_vec(dark_png);
         let dark_nsimage = NSImage::initWithData(NSImage::alloc(), &dark_nsdata).unwrap();
         let new_size = NSSize::new(ICON_WIDTH, ICON_HEIGHT);
-
 
         let block = RcBlock::new(move |ns_rect: NSRect| {
             if is_object_dark(&ns_status_item) {

--- a/src/platform_impl/macos/mod.rs
+++ b/src/platform_impl/macos/mod.rs
@@ -5,15 +5,18 @@
 mod icon;
 use std::cell::{Cell, RefCell};
 
+use block2::{Block, RcBlock};
+use objc2::ffi::id;
 use objc2::rc::Retained;
-use objc2::{define_class, msg_send, AllocAnyThread, DeclaredClass, Message};
+use objc2::runtime::{self, AnyObject};
+use objc2::{class, define_class, msg_send, sel, AllocAnyThread, DeclaredClass, Message};
 use objc2_app_kit::{
     NSCellImagePosition, NSEvent, NSImage, NSMenu, NSStatusBar, NSStatusItem, NSTrackingArea,
     NSTrackingAreaOptions, NSVariableStatusItemLength, NSView, NSWindow,
 };
 use objc2_core_foundation::{CGPoint, CGRect, CGSize};
 use objc2_core_graphics::{CGDisplayPixelsHigh, CGMainDisplayID};
-use objc2_foundation::{MainThreadMarker, NSData, NSSize, NSString};
+use objc2_foundation::{MainThreadMarker, NSData, NSRect, NSSize, NSString};
 
 pub(crate) use self::icon::PlatformIcon;
 use crate::Error;
@@ -118,6 +121,21 @@ impl TrayIcon {
             tray_target.update_dimensions();
         }
         self.attrs.icon = icon;
+        Ok(())
+    }
+
+    pub fn set_themed_icon(&mut self, light_icon: Icon, dark_icon: Icon) -> crate::Result<()> {
+        if let (Some(ns_status_item), Some(tray_target)) = (&self.ns_status_item, &self.tray_target)
+        {
+            set_themed_icon_for_ns_status_item_button(
+                ns_status_item,
+                light_icon.clone(),
+                dark_icon,
+                self.mtm,
+            )?;
+            tray_target.update_dimensions();
+        }
+        self.attrs.icon = Some(light_icon);
         Ok(())
     }
 
@@ -292,6 +310,46 @@ fn set_icon_for_ns_status_item_button(
         unsafe { button.setImage(None) };
     }
 
+    Ok(())
+}
+
+fn set_themed_icon_for_ns_status_item_button(
+    ns_status_item: &Retained<NSStatusItem>,
+    light_icon: Icon,
+    dark_icon: Icon,
+    mtm: MainThreadMarker,
+) -> crate::Result<()> {
+    const ICON_WIDTH: f64 = 18.0;
+    const ICON_HEIGHT: f64 = 18.0;
+    let light_png: Vec<u8> = light_icon.inner.to_png()?;
+    let dark_png: Vec<u8> = dark_icon.inner.to_png()?;
+    let ns_status_item = ns_status_item.clone();
+
+    let button = unsafe { ns_status_item.button(mtm).unwrap() };
+
+    unsafe {
+        let light_nsdata = NSData::from_vec(light_png);
+        let light_nsimage = NSImage::initWithData(NSImage::alloc(), &light_nsdata).unwrap();
+        let dark_nsdata = NSData::from_vec(dark_png);
+        let dark_nsimage = NSImage::initWithData(NSImage::alloc(), &dark_nsdata).unwrap();
+        let new_size = NSSize::new(ICON_WIDTH, ICON_HEIGHT);
+
+
+        let block = RcBlock::new(move |ns_rect: NSRect| {
+            if is_object_dark(&ns_status_item) {
+                dark_nsimage.drawInRect(ns_rect);
+            } else {
+                light_nsimage.drawInRect(ns_rect);
+            }
+            runtime::Bool::YES
+        });
+
+        let nsimage = NSImage::imageWithSize_flipped_drawingHandler(new_size, true, &block);
+
+        nsimage.setTemplate(false);
+
+        button.setImage(Some(&nsimage));
+    }
     Ok(())
 }
 
@@ -584,4 +642,44 @@ struct MouseClickEvent {
 /// to convert between the two coordinate systems.
 fn flip_window_screen_coordinates(y: f64) -> f64 {
     unsafe { CGDisplayPixelsHigh(CGMainDisplayID()) as f64 - y }
+}
+
+extern "C" {
+    static NSAppearanceNameAqua: *const AnyObject;
+    static NSAppearanceNameAccessibilityHighContrastAqua: *const AnyObject;
+    static NSAppearanceNameDarkAqua: *const AnyObject;
+    static NSAppearanceNameAccessibilityHighContrastDarkAqua: *const AnyObject;
+}
+
+unsafe fn is_object_dark(object: &NSStatusItem) -> bool {
+    let appearance: *const AnyObject = msg_send![object, effectiveAppearance];
+
+    let objects = [
+        NSAppearanceNameAqua,
+        NSAppearanceNameAccessibilityHighContrastAqua,
+        NSAppearanceNameDarkAqua,
+        NSAppearanceNameAccessibilityHighContrastDarkAqua,
+    ];
+    let names: *const AnyObject = msg_send![
+        class!(NSArray),
+        arrayWithObjects:objects.as_ptr(),
+        count:objects.len()
+    ];
+
+    // `bestMatchFromAppearancesWithNames` is only available in macOS 10.14+.
+    // Gracefully handle earlier versions.
+    let responds_to_selector: runtime::Bool = msg_send![
+        appearance,
+        respondsToSelector: sel!(bestMatchFromAppearancesWithNames:)
+    ];
+    if responds_to_selector == runtime::Bool::NO {
+        return false;
+    }
+
+    let style: *const AnyObject = msg_send![
+        appearance,
+        bestMatchFromAppearancesWithNames:&*names
+    ];
+
+    style == NSAppearanceNameDarkAqua || style == NSAppearanceNameAccessibilityHighContrastDarkAqua
 }

--- a/src/platform_impl/macos/mod.rs
+++ b/src/platform_impl/macos/mod.rs
@@ -7,15 +7,18 @@ use std::cell::{Cell, RefCell};
 
 use block2::RcBlock;
 use objc2::rc::Retained;
-use objc2::runtime::{self, AnyObject};
-use objc2::{class, define_class, msg_send, sel, AllocAnyThread, DeclaredClass, Message};
+use objc2::runtime::Bool;
+use objc2::{available, define_class, msg_send, AllocAnyThread, DeclaredClass, Message};
 use objc2_app_kit::{
-    NSCellImagePosition, NSEvent, NSImage, NSMenu, NSStatusBar, NSStatusItem, NSTrackingArea,
-    NSTrackingAreaOptions, NSVariableStatusItemLength, NSView, NSWindow,
+    NSAppearanceCustomization, NSAppearanceNameAccessibilityHighContrastAqua,
+    NSAppearanceNameAccessibilityHighContrastDarkAqua, NSAppearanceNameAqua,
+    NSAppearanceNameDarkAqua, NSCellImagePosition, NSEvent, NSImage, NSMenu, NSStatusBar,
+    NSStatusBarButton, NSStatusItem, NSTrackingArea, NSTrackingAreaOptions,
+    NSVariableStatusItemLength, NSView, NSWindow,
 };
 use objc2_core_foundation::{CGPoint, CGRect, CGSize};
 use objc2_core_graphics::{CGDisplayPixelsHigh, CGMainDisplayID};
-use objc2_foundation::{MainThreadMarker, NSData, NSRect, NSSize, NSString};
+use objc2_foundation::{MainThreadMarker, NSArray, NSData, NSRect, NSSize, NSString};
 
 pub(crate) use self::icon::PlatformIcon;
 use crate::Error;
@@ -326,28 +329,30 @@ fn set_themed_icon_for_ns_status_item_button(
 
     let button = unsafe { ns_status_item.button(mtm).unwrap() };
 
+    let light_nsdata = NSData::from_vec(light_png);
+    let light_nsimage = NSImage::initWithData(NSImage::alloc(), &light_nsdata).unwrap();
+    let dark_nsdata = NSData::from_vec(dark_png);
+    let dark_nsimage = NSImage::initWithData(NSImage::alloc(), &dark_nsdata).unwrap();
+    let new_size = NSSize::new(ICON_WIDTH, ICON_HEIGHT);
+
+    let button_clone = button.clone();
+    let block = RcBlock::new(move |ns_rect: NSRect| unsafe {
+        if is_button_dark(&button_clone) {
+            dark_nsimage.drawInRect(ns_rect);
+        } else {
+            light_nsimage.drawInRect(ns_rect);
+        }
+        Bool::YES
+    });
+
     unsafe {
-        let light_nsdata = NSData::from_vec(light_png);
-        let light_nsimage = NSImage::initWithData(NSImage::alloc(), &light_nsdata).unwrap();
-        let dark_nsdata = NSData::from_vec(dark_png);
-        let dark_nsimage = NSImage::initWithData(NSImage::alloc(), &dark_nsdata).unwrap();
-        let new_size = NSSize::new(ICON_WIDTH, ICON_HEIGHT);
-
-        let block = RcBlock::new(move |ns_rect: NSRect| {
-            if is_object_dark(&ns_status_item) {
-                dark_nsimage.drawInRect(ns_rect);
-            } else {
-                light_nsimage.drawInRect(ns_rect);
-            }
-            runtime::Bool::YES
-        });
-
         let nsimage = NSImage::imageWithSize_flipped_drawingHandler(new_size, true, &block);
 
         nsimage.setTemplate(false);
 
         button.setImage(Some(&nsimage));
     }
+
     Ok(())
 }
 
@@ -642,42 +647,25 @@ fn flip_window_screen_coordinates(y: f64) -> f64 {
     unsafe { CGDisplayPixelsHigh(CGMainDisplayID()) as f64 - y }
 }
 
-extern "C" {
-    static NSAppearanceNameAqua: *const AnyObject;
-    static NSAppearanceNameAccessibilityHighContrastAqua: *const AnyObject;
-    static NSAppearanceNameDarkAqua: *const AnyObject;
-    static NSAppearanceNameAccessibilityHighContrastDarkAqua: *const AnyObject;
-}
-
-unsafe fn is_object_dark(object: &NSStatusItem) -> bool {
-    let appearance: *const AnyObject = msg_send![object, effectiveAppearance];
-
-    let objects = [
-        NSAppearanceNameAqua,
-        NSAppearanceNameAccessibilityHighContrastAqua,
-        NSAppearanceNameDarkAqua,
-        NSAppearanceNameAccessibilityHighContrastDarkAqua,
-    ];
-    let names: *const AnyObject = msg_send![
-        class!(NSArray),
-        arrayWithObjects:objects.as_ptr(),
-        count:objects.len()
-    ];
-
+fn is_button_dark(button: &NSStatusBarButton) -> bool {
     // `bestMatchFromAppearancesWithNames` is only available in macOS 10.14+.
-    // Gracefully handle earlier versions.
-    let responds_to_selector: runtime::Bool = msg_send![
-        appearance,
-        respondsToSelector: sel!(bestMatchFromAppearancesWithNames:)
-    ];
-    if responds_to_selector == runtime::Bool::NO {
+    if !available!(macos = 10.14) {
         return false;
     }
 
-    let style: *const AnyObject = msg_send![
-        appearance,
-        bestMatchFromAppearancesWithNames:&*names
-    ];
-
-    style == NSAppearanceNameDarkAqua || style == NSAppearanceNameAccessibilityHighContrastDarkAqua
+    let appearance = unsafe { button.effectiveAppearance() };
+    let style = appearance.bestMatchFromAppearancesWithNames(&NSArray::from_slice(unsafe {
+        &[
+            NSAppearanceNameAqua,
+            NSAppearanceNameAccessibilityHighContrastAqua,
+            NSAppearanceNameDarkAqua,
+            NSAppearanceNameAccessibilityHighContrastDarkAqua,
+        ]
+    }));
+    style
+        .map(|style| unsafe {
+            style.isEqualToString(NSAppearanceNameDarkAqua)
+                || style.isEqualToString(NSAppearanceNameAccessibilityHighContrastDarkAqua)
+        })
+        .unwrap_or(false)
 }

--- a/src/platform_impl/macos/mod.rs
+++ b/src/platform_impl/macos/mod.rs
@@ -4,6 +4,7 @@
 
 mod icon;
 use std::cell::{Cell, RefCell};
+use std::cmp::max;
 
 use block2::RcBlock;
 use objc2::rc::Retained;
@@ -60,12 +61,21 @@ impl TrayIcon {
             NSStatusBar::systemStatusBar().statusItemWithLength(NSVariableStatusItemLength)
         };
 
-        set_icon_for_ns_status_item_button(
-            &ns_status_item,
-            attrs.icon.clone(),
-            attrs.icon_is_template,
-            mtm,
-        )?;
+        if let (Some(dark), Some(light)) = (&attrs.dark_icon, &attrs.icon) {
+            set_themed_icon_for_ns_status_item_button(
+                &ns_status_item,
+                light.clone(),
+                dark.clone(),
+                mtm,
+            )?;
+        } else {
+            set_icon_for_ns_status_item_button(
+                &ns_status_item,
+                attrs.icon.clone(),
+                attrs.icon_is_template,
+                mtm,
+            )?;
+        }
 
         if let Some(menu) = &attrs.menu {
             unsafe {
@@ -123,6 +133,7 @@ impl TrayIcon {
             tray_target.update_dimensions();
         }
         self.attrs.icon = icon;
+        self.attrs.dark_icon = None;
         Ok(())
     }
 
@@ -132,12 +143,13 @@ impl TrayIcon {
             set_themed_icon_for_ns_status_item_button(
                 ns_status_item,
                 light_icon.clone(),
-                dark_icon,
+                dark_icon.clone(),
                 self.mtm,
             )?;
             tray_target.update_dimensions();
         }
         self.attrs.icon = Some(light_icon);
+        self.attrs.dark_icon = Some(dark_icon);
         Ok(())
     }
 
@@ -321,8 +333,13 @@ fn set_themed_icon_for_ns_status_item_button(
     dark_icon: Icon,
     mtm: MainThreadMarker,
 ) -> crate::Result<()> {
-    const ICON_WIDTH: f64 = 18.0;
     const ICON_HEIGHT: f64 = 18.0;
+
+    let (light_width, light_height) = light_icon.inner.get_size();
+    let (dark_width, dark_height) = dark_icon.inner.get_size();
+    let icon_width: f64 = (max(light_width, dark_width) as f64)
+        / (max(light_height, dark_height) as f64 / ICON_HEIGHT);
+
     let light_png: Vec<u8> = light_icon.inner.to_png()?;
     let dark_png: Vec<u8> = dark_icon.inner.to_png()?;
     let ns_status_item = ns_status_item.clone();
@@ -333,24 +350,24 @@ fn set_themed_icon_for_ns_status_item_button(
     let light_nsimage = NSImage::initWithData(NSImage::alloc(), &light_nsdata).unwrap();
     let dark_nsdata = NSData::from_vec(dark_png);
     let dark_nsimage = NSImage::initWithData(NSImage::alloc(), &dark_nsdata).unwrap();
-    let new_size = NSSize::new(ICON_WIDTH, ICON_HEIGHT);
+    let nssize = NSSize::new(icon_width, ICON_HEIGHT);
 
     let button_clone = button.clone();
     let block = RcBlock::new(move |ns_rect: NSRect| unsafe {
         if is_button_dark(&button_clone) {
-            dark_nsimage.drawInRect(ns_rect);
-        } else {
             light_nsimage.drawInRect(ns_rect);
+        } else {
+            dark_nsimage.drawInRect(ns_rect);
         }
         Bool::YES
     });
 
     unsafe {
-        let nsimage = NSImage::imageWithSize_flipped_drawingHandler(new_size, true, &block);
-
+        let nsimage = NSImage::imageWithSize_flipped_drawingHandler(nssize, true, &block);
         nsimage.setTemplate(false);
 
         button.setImage(Some(&nsimage));
+        button.setImagePosition(NSCellImagePosition::ImageLeft);
     }
 
     Ok(())


### PR DESCRIPTION
Currently on MacOS you can set your icon as a [template](https://github.com/tauri-apps/tray-icon/blob/dev/src/lib.rs#L178) to have the icon change color dynamically with the bar's theme. Unfortunately this prevents using colors in your system icon since the image is used as a mask. This PR adds the ability to have colored icons that react to the system bar's theme.


[Demo.webm](https://github.com/user-attachments/assets/f8fb36d2-8598-450c-b402-a6d941a55bd2)

There is a little more clean up to do, but I figured I'd open the PR to see if it's something you're interested in merging before I spend more time on it. Please let me know if you see any major problems with this approach. I'm also open to taking a stab at implementing similar functionality for windows.