### PR TITLE
Add Linux KSNI tray backend

### DIFF
--- a/.changes/linux-ksni.md
+++ b/.changes/linux-ksni.md
@@ -1,0 +1,5 @@
+---
+tray-icon: minor
+---
+
+Add a `linux-ksni` feature that uses the KDE/freedesktop StatusNotifierItem tray backend on Linux instead of GTK/libappindicator.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2280,7 +2280,7 @@ dependencies = [
 [[package]]
 name = "muda"
 version = "0.19.3"
-source = "git+https://github.com/OlympusLedgerOrg/muda?branch=codex/linux-ksni-api#76e8f3f3638439ec2b223cbd7c11771332571b0a"
+source = "git+https://github.com/OlympusLedgerOrg/muda?branch=codex/linux-ksni-api#2e8d21d83bf19df078240ad3747f514f357b8491"
 dependencies = [
  "arc-swap",
  "crossbeam-channel",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -922,7 +922,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2280,7 +2280,7 @@ dependencies = [
 [[package]]
 name = "muda"
 version = "0.19.3"
-source = "git+https://github.com/OlympusLedgerOrg/muda?branch=codex/linux-ksni-api#762a0d08536353798d38732ebd28970f97556f51"
+source = "git+https://github.com/OlympusLedgerOrg/muda?branch=codex/linux-ksni-api#76e8f3f3638439ec2b223cbd7c11771332571b0a"
 dependencies = [
  "arc-swap",
  "crossbeam-channel",
@@ -2296,7 +2296,7 @@ dependencies = [
  "png 0.18.0",
  "serde",
  "thiserror 2.0.11",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3673,7 +3673,7 @@ dependencies = [
  "serde_json",
  "tao",
  "thiserror 2.0.11",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
  "winit",
 ]
 
@@ -4357,15 +4357,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -4412,28 +4403,11 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
+ "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link 0.2.1",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -4464,12 +4438,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4486,12 +4454,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4512,22 +4474,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4548,12 +4498,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4570,12 +4514,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4596,12 +4534,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4618,12 +4550,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winit"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,6 +166,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "arboard"
 version = "3.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -181,6 +190,15 @@ dependencies = [
  "parking_lot",
  "windows-sys 0.48.0",
  "x11rb",
+]
+
+[[package]]
+name = "arc-swap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -434,6 +452,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi 0.1.19",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -659,6 +688,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "2.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+dependencies = [
+ "ansi_term",
+ "atty",
+ "bitflags 1.3.2",
+ "strsim",
+ "textwrap",
+ "unicode-width",
+ "vec_map",
+]
+
+[[package]]
 name = "clipboard-win"
 version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -818,6 +862,37 @@ name = "cursor-icon"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96a6ac251f4a2aca6b3f91340350eab87ae57c3f127ffeb585e92bd336717991"
+
+[[package]]
+name = "dbus"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ab69f03cc8c4340c9c8e315114e1658e6775a9b16a04357973aa21cec22b32e"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dbus-codegen"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a49da9fdfbe872d4841d56605dc42efa5e6ca3291299b87f44e1cde91a28617c"
+dependencies = [
+ "clap",
+ "dbus",
+ "xml-rs",
+]
+
+[[package]]
+name = "dbus-tree"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f456e698ae8e54575e19ddb1f9b7bce2298568524f215496b248eb9498b4f508"
+dependencies = [
+ "dbus",
+]
 
 [[package]]
 name = "digest"
@@ -1717,6 +1792,15 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "hermit-abi"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
@@ -1995,6 +2079,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
+name = "ksni"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4934310bdd016e55725482b8d35ac0c16fd058c1b955d8959aa2d953b918c85b"
+dependencies = [
+ "dbus",
+ "dbus-codegen",
+ "dbus-tree",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2029,6 +2125,15 @@ name = "libc"
 version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+
+[[package]]
+name = "libdbus-sys"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
+dependencies = [
+ "pkg-config",
+]
 
 [[package]]
 name = "libloading"
@@ -2174,10 +2279,10 @@ dependencies = [
 
 [[package]]
 name = "muda"
-version = "0.19.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ae8844f63b5b118e334e205585b8c5c17b984121dbdb179d44aeb087ffad3cb"
+version = "0.19.3"
+source = "git+https://github.com/OlympusLedgerOrg/muda?branch=codex/linux-ksni-api#762a0d08536353798d38732ebd28970f97556f51"
 dependencies = [
+ "arc-swap",
  "crossbeam-channel",
  "dpi",
  "gtk",
@@ -2767,7 +2872,7 @@ checksum = "a604568c3202727d1507653cb121dbd627a58684eb09a820fd746bee38b4442f"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
- "hermit-abi",
+ "hermit-abi 0.4.0",
  "pin-project-lite",
  "rustix",
  "tracing",
@@ -3210,6 +3315,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
 
 [[package]]
+name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
 name = "strum"
 version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3354,6 +3465,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -3533,11 +3653,13 @@ dependencies = [
 name = "tray-icon"
 version = "0.24.1"
 dependencies = [
+ "arc-swap",
  "crossbeam-channel",
  "dirs",
  "eframe",
  "gtk",
  "image",
+ "ksni",
  "libappindicator",
  "muda",
  "objc2 0.6.4",
@@ -3633,6 +3755,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version-compare"
@@ -4234,6 +4362,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
  "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,11 @@ libxdo = ["muda/libxdo"]
 serde = ["muda/serde", "dep:serde"]
 common-controls-v6 = ["muda/common-controls-v6"]
 gtk = ["muda/gtk", "dep:libappindicator"]
+linux-ksni = ["dep:arc-swap", "dep:ksni", "muda/linux-ksni"]
 
 [dependencies]
-muda = { version = "0.19.1", default-features = false }
+muda = { git = "https://github.com/OlympusLedgerOrg/muda", branch = "codex/linux-ksni-api", default-features = false }
+arc-swap = { version = "1.7.1", optional = true }
 crossbeam-channel = "0.5"
 once_cell = "1"
 thiserror = "2"
@@ -43,6 +45,7 @@ features = [
 
 [target."cfg(any(target_os = \"linux\", target_os = \"dragonfly\", target_os = \"freebsd\", target_os = \"netbsd\", target_os = \"openbsd\"))".dependencies]
 libappindicator = { version = "0.9", optional = true }
+ksni = { version = "0.2.2", optional = true }
 dirs = "6"
 
 [target."cfg(any(target_os = \"linux\", target_os = \"dragonfly\", target_os = \"freebsd\", target_os = \"netbsd\", target_os = \"openbsd\"))".dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ tray-icon lets you create tray icons for desktop applications.
 
 - Windows
 - macOS
-- Linux (gtk Only)
+- Linux (gtk or KSNI)
 - FreeBSD (gtk Only)
 
 ## Platform-specific notes:
@@ -17,10 +17,11 @@ tray-icon lets you create tray icons for desktop applications.
 - `common-controls-v6`: Use `TaskDialogIndirect` API from `ComCtl32.dll` v6 on Windows for showing the predefined `About` menu item dialog.
 - `libxdo`: Enables linking to `libxdo` which is used for the predfined `Copy`, `Cut`, `Paste` and `SelectAll` menu item, see https://github.com/tauri-apps/muda#cargo-features
 - `serde`: Enables de/serializing derives.
+- `linux-ksni`: Uses the KDE/freedesktop StatusNotifierItem backend on Linux instead of the default GTK/libappindicator backend.
 
 ## Dependencies (Linux Only)
 
-On Linux, `gtk`, `libxdo` is used to make the predfined `Copy`, `Cut`, `Paste` and `SelectAll` menu items work and `libappindicator` or `libayatnat-appindicator` are used to create the tray icon, so make sure to install them on your system.
+With the default Linux backend, `gtk`, `libxdo` is used to make the predfined `Copy`, `Cut`, `Paste` and `SelectAll` menu items work and `libappindicator` or `libayatnat-appindicator` are used to create the tray icon, so make sure to install them on your system. The `linux-ksni` feature uses StatusNotifierItem instead of libappindicator.
 
 #### Arch Linux / Manjaro:
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,16 +10,16 @@
 //!
 //! - Windows
 //! - macOS
-//! - Linux (gtk Only)
+//! - Linux (gtk or KSNI)
 //!
 //! # Platform-specific notes:
 //!
-//! - On Windows and Linux, an event loop must be running on the thread, on Windows, a win32 event loop and on Linux, a gtk event loop. It doesn't need to be the main thread but you have to create the tray icon on the same thread as the event loop.
+//! - On Windows and default Linux GTK builds, an event loop must be running on the thread, on Windows, a win32 event loop and on Linux, a gtk event loop. It doesn't need to be the main thread but you have to create the tray icon on the same thread as the event loop.
 //! - On macOS, an event loop must be running on the main thread so you also need to create the tray icon on the main thread. You must make sure that the event loop is already running and not just created before creating a TrayIcon to prevent issues with fullscreen apps. In Winit for example the earliest you can create icons is on [`StartCause::Init`](https://docs.rs/winit/latest/winit/event/enum.StartCause.html#variant.Init).
 //!
 //! # Dependencies (Linux Only)
 //!
-//! On Linux, `gtk`, `libxdo` is used to make the predfined `Copy`, `Cut`, `Paste` and `SelectAll` menu items work and `libappindicator` or `libayatnat-appindicator` are used to create the tray icon, so make sure to install them on your system.
+//! With the default Linux backend, `gtk`, `libxdo` is used to make the predfined `Copy`, `Cut`, `Paste` and `SelectAll` menu items work and `libappindicator` or `libayatnat-appindicator` are used to create the tray icon, so make sure to install them on your system. The `linux-ksni` feature uses StatusNotifierItem instead of libappindicator.
 //!
 //! #### Arch Linux / Manjaro:
 //!
@@ -537,7 +537,12 @@ impl TrayIcon {
     /// # Safety
     ///
     /// The returned pointer is valid as long as the `TrayIcon` is.
-    #[cfg(all(unix, not(target_os = "macos")))]
+    #[cfg(all(
+        unix,
+        not(target_os = "macos"),
+        feature = "gtk",
+        not(all(target_os = "linux", feature = "linux-ksni"))
+    ))]
     pub unsafe fn app_indicator(&self) -> *const libappindicator::AppIndicator {
         self.tray.borrow().app_indicator() as *const _
     }

--- a/src/platform_impl/linux/icon.rs
+++ b/src/platform_impl/linux/icon.rs
@@ -1,0 +1,60 @@
+// Copyright 2022-2022 Tauri Programme within The Commons Conservancy
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: MIT
+
+use crate::icon::BadIcon;
+
+#[derive(Debug, Clone)]
+pub struct PlatformIcon {
+    argb: Vec<u8>,
+    width: i32,
+    height: i32,
+}
+
+impl PlatformIcon {
+    pub fn from_rgba(rgba: Vec<u8>, width: u32, height: u32) -> Result<Self, BadIcon> {
+        let mut bytes = rgba;
+        for pixel in bytes.chunks_exact_mut(4) {
+            let r = pixel[0];
+            let g = pixel[1];
+            let b = pixel[2];
+            let a = pixel[3];
+            pixel[0] = a;
+            pixel[1] = r;
+            pixel[2] = g;
+            pixel[3] = b;
+        }
+
+        Ok(Self {
+            argb: bytes,
+            width: width as i32,
+            height: height as i32,
+        })
+    }
+
+    pub fn into_rgba(self) -> (Vec<u8>, u32, u32) {
+        let mut bytes = self.argb;
+        for pixel in bytes.chunks_exact_mut(4) {
+            let a = pixel[0];
+            let r = pixel[1];
+            let g = pixel[2];
+            let b = pixel[3];
+            pixel[0] = r;
+            pixel[1] = g;
+            pixel[2] = b;
+            pixel[3] = a;
+        }
+
+        (bytes, self.width as u32, self.height as u32)
+    }
+}
+
+impl From<PlatformIcon> for ksni::Icon {
+    fn from(icon: PlatformIcon) -> Self {
+        ksni::Icon {
+            width: icon.width,
+            height: icon.height,
+            data: icon.argb,
+        }
+    }
+}

--- a/src/platform_impl/linux/menu.rs
+++ b/src/platform_impl/linux/menu.rs
@@ -1,0 +1,53 @@
+use std::sync::Arc;
+
+use arc_swap::ArcSwap;
+
+use super::tray::Tray;
+
+pub fn muda_to_ksni_menu_item(
+    item: Arc<ArcSwap<muda::CompatMenuItem>>,
+) -> ksni::menu::MenuItem<Tray> {
+    match &**item.load() {
+        muda::CompatMenuItem::Standard(menu_item) => {
+            let id = menu_item.id.clone();
+            ksni::menu::StandardItem {
+                label: menu_item.label.clone(),
+                enabled: menu_item.enabled,
+                icon_data: menu_item.icon.clone().unwrap_or_default(),
+                activate: Box::new(move |_| send_menu_event(&id)),
+                ..Default::default()
+            }
+            .into()
+        }
+        muda::CompatMenuItem::Checkmark(check_menu_item) => {
+            let id = check_menu_item.id.clone();
+            ksni::menu::CheckmarkItem {
+                label: check_menu_item.label.clone(),
+                enabled: check_menu_item.enabled,
+                checked: check_menu_item.checked,
+                activate: Box::new(move |_| send_menu_event(&id)),
+                ..Default::default()
+            }
+            .into()
+        }
+        muda::CompatMenuItem::SubMenu(submenu) => ksni::menu::SubMenu {
+            label: submenu.label.clone(),
+            enabled: submenu.enabled,
+            submenu: submenu
+                .submenu
+                .iter()
+                .cloned()
+                .map(muda_to_ksni_menu_item)
+                .collect(),
+            ..Default::default()
+        }
+        .into(),
+        muda::CompatMenuItem::Separator => ksni::menu::MenuItem::Separator,
+    }
+}
+
+fn send_menu_event(id: &str) {
+    muda::MenuEvent::send(muda::MenuEvent {
+        id: muda::MenuId(id.to_string()),
+    })
+}

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -1,0 +1,119 @@
+// Copyright 2022-2022 Tauri Programme within The Commons Conservancy
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-License-Identifier: MIT
+
+mod icon;
+mod menu;
+mod tray;
+
+use std::{
+    path::Path,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    thread,
+};
+
+pub(crate) use icon::PlatformIcon;
+use tray::Tray;
+
+use crate::{icon::Icon, TrayIconAttributes, TrayIconId};
+
+pub struct TrayIcon {
+    tray_handle: ksni::Handle<Tray>,
+    shutdown: Arc<AtomicBool>,
+}
+
+impl TrayIcon {
+    pub fn new(id: TrayIconId, attrs: TrayIconAttributes) -> crate::Result<Self> {
+        let icon = attrs.icon.map(|icon| icon.inner.into());
+        let title = attrs.title.unwrap_or_default();
+        let tooltip = attrs.tooltip.unwrap_or_default();
+        let menu = attrs
+            .menu
+            .as_ref()
+            .map(|menu| menu.compat_items())
+            .unwrap_or_default();
+
+        let shutdown = Arc::new(AtomicBool::new(false));
+
+        let tray_service = ksni::TrayService::new(Tray::new(id, icon, title, tooltip, menu));
+        let tray_handle = tray_service.handle();
+        tray_service.spawn();
+
+        let update_tray_handle = tray_handle.clone();
+        let update_shutdown = shutdown.clone();
+        thread::spawn(move || {
+            while muda::recv_menu_update().is_ok() {
+                if update_shutdown.load(Ordering::Relaxed) {
+                    break;
+                }
+                update_tray_handle.update(|_| {});
+            }
+        });
+
+        Ok(Self {
+            tray_handle,
+            shutdown,
+        })
+    }
+
+    pub fn set_icon(&mut self, icon: Option<Icon>) -> crate::Result<()> {
+        let icon = icon.map(|icon| icon.inner.into());
+        self.tray_handle.update(|tray| tray.set_icon(icon));
+        Ok(())
+    }
+
+    pub fn set_menu(&mut self, menu: Option<Box<dyn crate::menu::ContextMenu>>) {
+        let menu = menu
+            .as_ref()
+            .map(|menu| menu.compat_items())
+            .unwrap_or_default();
+        self.tray_handle.update(|tray| tray.set_menu(menu));
+    }
+
+    pub fn set_tooltip<S: AsRef<str>>(&mut self, tooltip: Option<S>) -> crate::Result<()> {
+        let tooltip = tooltip
+            .as_ref()
+            .map(AsRef::as_ref)
+            .unwrap_or_default()
+            .to_string();
+        self.tray_handle.update(|tray| tray.set_tooltip(tooltip));
+        Ok(())
+    }
+
+    pub fn set_title<S: AsRef<str>>(&mut self, title: Option<S>) {
+        let title = title
+            .as_ref()
+            .map(AsRef::as_ref)
+            .unwrap_or_default()
+            .to_string();
+        self.tray_handle.update(|tray| tray.set_title(title));
+    }
+
+    pub fn set_visible(&mut self, visible: bool) -> crate::Result<()> {
+        self.tray_handle.update(|tray| {
+            tray.set_status(if visible {
+                ksni::Status::Active
+            } else {
+                ksni::Status::Passive
+            });
+        });
+        Ok(())
+    }
+
+    pub fn set_temp_dir_path<P: AsRef<Path>>(&mut self, _path: Option<P>) {}
+
+    pub fn rect(&self) -> Option<crate::Rect> {
+        None
+    }
+}
+
+impl Drop for TrayIcon {
+    fn drop(&mut self) {
+        self.shutdown.store(true, Ordering::Relaxed);
+        muda::send_menu_update();
+        self.tray_handle.shutdown();
+    }
+}

--- a/src/platform_impl/linux/tray.rs
+++ b/src/platform_impl/linux/tray.rs
@@ -1,0 +1,112 @@
+use std::sync::Arc;
+
+use arc_swap::ArcSwap;
+
+use crate::{MouseButton, MouseButtonState, TrayIconEvent, TrayIconId};
+
+use super::menu::muda_to_ksni_menu_item;
+
+pub struct Tray {
+    id: TrayIconId,
+    icon: Vec<ksni::Icon>,
+    title: String,
+    status: ksni::Status,
+    tooltip: String,
+    menu: Vec<Arc<ArcSwap<muda::CompatMenuItem>>>,
+}
+
+impl Tray {
+    pub fn new(
+        id: TrayIconId,
+        icon: Option<ksni::Icon>,
+        title: String,
+        tooltip: String,
+        menu: Vec<Arc<ArcSwap<muda::CompatMenuItem>>>,
+    ) -> Self {
+        Self {
+            id,
+            icon: icon.into_iter().collect(),
+            title,
+            status: ksni::Status::Active,
+            tooltip,
+            menu,
+        }
+    }
+
+    pub fn set_icon(&mut self, icon: Option<ksni::Icon>) {
+        self.icon = icon.into_iter().collect();
+    }
+
+    pub fn set_menu(&mut self, menu: Vec<Arc<ArcSwap<muda::CompatMenuItem>>>) {
+        self.menu = menu;
+    }
+
+    pub fn set_status(&mut self, status: ksni::Status) {
+        self.status = status;
+    }
+
+    pub fn set_title(&mut self, title: String) {
+        self.title = title;
+    }
+
+    pub fn set_tooltip(&mut self, tooltip: String) {
+        self.tooltip = tooltip;
+    }
+}
+
+impl ksni::Tray for Tray {
+    fn id(&self) -> String {
+        self.id.0.clone()
+    }
+
+    fn status(&self) -> ksni::Status {
+        self.status
+    }
+
+    fn icon_pixmap(&self) -> Vec<ksni::Icon> {
+        self.icon.clone()
+    }
+
+    fn title(&self) -> String {
+        self.title.clone()
+    }
+
+    fn tool_tip(&self) -> ksni::ToolTip {
+        ksni::ToolTip {
+            icon_pixmap: self.icon.clone(),
+            title: self.title.clone(),
+            description: self.tooltip.clone(),
+            ..Default::default()
+        }
+    }
+
+    fn menu(&self) -> Vec<ksni::MenuItem<Self>> {
+        self.menu
+            .iter()
+            .cloned()
+            .map(muda_to_ksni_menu_item)
+            .collect()
+    }
+
+    fn activate(&mut self, x: i32, y: i32) {
+        let event = TrayIconEvent::Click {
+            id: self.id.clone(),
+            position: muda::dpi::PhysicalPosition::new(x as f64, y as f64),
+            rect: Default::default(),
+            button: MouseButton::Left,
+            button_state: MouseButtonState::Up,
+        };
+        TrayIconEvent::send(event);
+    }
+
+    fn secondary_activate(&mut self, x: i32, y: i32) {
+        let event = TrayIconEvent::Click {
+            id: self.id.clone(),
+            position: muda::dpi::PhysicalPosition::new(x as f64, y as f64),
+            rect: Default::default(),
+            button: MouseButton::Middle,
+            button_state: MouseButtonState::Up,
+        };
+        TrayIconEvent::send(event);
+    }
+}

--- a/src/platform_impl/mod.rs
+++ b/src/platform_impl/mod.rs
@@ -6,13 +6,16 @@
 #[path = "windows/mod.rs"]
 mod platform;
 #[cfg(any(
-    target_os = "linux",
+    all(target_os = "linux", not(feature = "linux-ksni")),
     target_os = "dragonfly",
     target_os = "freebsd",
     target_os = "netbsd",
     target_os = "openbsd"
 ))]
 #[path = "gtk/mod.rs"]
+mod platform;
+#[cfg(all(target_os = "linux", feature = "linux-ksni"))]
+#[path = "linux/mod.rs"]
 mod platform;
 #[cfg(target_os = "macos")]
 #[path = "macos/mod.rs"]


### PR DESCRIPTION
Summary: add an optional linux-ksni feature that uses KDE/freedesktop StatusNotifierItem instead of the default GTK/libappindicator backend; add a Linux KSNI platform implementation for icons, menu conversion, events, visibility, title, and tooltip; gate the AppIndicator accessor to the GTK backend and update docs. This is stacked on tauri-apps/muda#372, so the muda dependency points at that branch until the prerequisite is released. Validation: cargo check; WSL cargo check --target x86_64-unknown-linux-gnu --no-default-features --features linux-ksni.