### PR TITLE
fix: forwarding click events on macOS 27

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ objc2-app-kit = { version = "0.3", default-features = false, features = [
   "NSEvent",
   "NSImage",
   "NSMenu",
+  "NSMenuItem",
   "NSResponder",
   "NSStatusBar",
   "NSStatusBarButton",

--- a/src/platform_impl/macos/mod.rs
+++ b/src/platform_impl/macos/mod.rs
@@ -62,12 +62,6 @@ impl TrayIcon {
             mtm,
         )?;
 
-        if let Some(menu) = &attrs.menu {
-            unsafe {
-                ns_status_item.setMenu((menu.ns_menu() as *const NSMenu).as_ref());
-            }
-        }
-
         Self::set_tooltip_inner(&ns_status_item, attrs.tooltip.as_deref(), mtm)?;
         Self::set_title_inner(&ns_status_item, attrs.title.as_deref(), mtm);
 
@@ -123,17 +117,12 @@ impl TrayIcon {
     }
 
     pub fn set_menu(&mut self, menu: Option<Box<dyn menu::ContextMenu>>) {
-        if let (Some(ns_status_item), Some(tray_target)) = (&self.ns_status_item, &self.tray_target)
-        {
+        if let (Some(_), Some(tray_target)) = (&self.ns_status_item, &self.tray_target) {
             unsafe {
                 let menu = menu
                     .as_ref()
                     .and_then(|m| m.ns_menu().cast::<NSMenu>().as_ref())
                     .map(|menu| menu.retain());
-                ns_status_item.setMenu(menu.as_deref());
-                if let Some(menu) = &menu {
-                    let () = msg_send![menu, setDelegate: &**ns_status_item];
-                }
 
                 *tray_target.ivars().menu.borrow_mut() = menu;
             }
@@ -490,6 +479,7 @@ fn on_tray_click(this: &TrayTarget, button: MouseButton) {
     let mtm = MainThreadMarker::from(this);
     unsafe {
         let ns_button = this.ivars().status_item.button(mtm).unwrap();
+        let status_item = &this.ivars().status_item;
 
         let menu_on_left_click = this.ivars().menu_on_left_click.get();
         let menu_on_right_click = this.ivars().menu_on_right_click.get();
@@ -502,7 +492,11 @@ fn on_tray_click(this: &TrayTarget, button: MouseButton) {
                 false
             };
             if has_items {
+                let menu = this.ivars().menu.borrow();
+                let menu = menu.as_ref().unwrap();
+                status_item.setMenu(Some(menu));
                 ns_button.performClick(None);
+                status_item.setMenu(None);
             } else {
                 ns_button.highlight(true);
             }


### PR DESCRIPTION
On macos 27 the left click events are not forwarded to the NSView while the status item has an NSMenu (I think this is because of [TN3212](https://developer.apple.com/documentation/technotes/tn3212-adopting-gesture-recognizers-for-sidecar-touch-support)). Here this is worked around by only calling setMenu after we've received the click event.

I've tested this on macOS 27.0 Beta (26A5378n).

Note that mouse Enter/Move/Exit events don't work on this version, there is [thread](https://developer.apple.com/forums/thread/836113) for this.