### PR TITLE
Asynchronously working egui example

### DIFF
--- a/examples/egui.rs
+++ b/examples/egui.rs
@@ -7,18 +7,19 @@
     target_os = "netbsd",
     target_os = "openbsd"
 )))]
-
 use std::{cell::RefCell, rc::Rc};
+
 use eframe::egui;
 use tray_icon::{
-    menu::{AboutMetadata, Menu, MenuEvent, MenuItem, PredefinedMenuItem},
-    TrayIconBuilder
+    TrayIcon, TrayIconBuilder, TrayIconEvent,
+    menu::{AboutMetadata, Menu, MenuEvent, MenuItem, PredefinedMenuItem}
 };
 
 
 fn main() -> Result<(), eframe::Error> {
     let path = concat!(env!("CARGO_MANIFEST_DIR"), "/examples/icon.png");
     let icon = load_icon(std::path::Path::new(path));
+    let menu_items = vec![MenuItem::new("Exit", true, None)];
 
     // Since egui uses winit under the hood and doesn't use gtk on Linux, and we need gtk for
     // the tray icon to show up, we need to spawn a thread
@@ -32,12 +33,7 @@ fn main() -> Result<(), eframe::Error> {
     ))]
     std::thread::spawn(|| {
         gtk::init().unwrap();
-        let _tray_icon = TrayIconBuilder::new()
-            .with_menu(Box::new(tray_menu))
-            .with_tooltip("Some tray example text :-)")
-            .with_icon(icon)
-            .build()
-            .unwrap();
+        let _tray_icon = create_tray_icon(icon, &menu_items);
 
         gtk::main();
     });
@@ -63,30 +59,7 @@ fn main() -> Result<(), eframe::Error> {
         "My egui App",
         eframe::NativeOptions::default(),
         Box::new(move |_cc| {
-            let app_struc = Box::<MyApp>::default();
-
-            // Create the tray menu and add the desired items
-            let tray_menu = Menu::new();
-
-            // Append those items that doesn't need to interact with the rest of
-            // the UI code
-            tray_menu.append_items(&[
-                &PredefinedMenuItem::about(
-                    None,
-                    Some(AboutMetadata {
-                        name: Some("egui example".to_string()),
-                        copyright: Some("Copyright egui example".to_string()),
-                        ..Default::default()
-                    }),
-                ),
-                &PredefinedMenuItem::separator(),
-            ]).expect("Error creating the tray icon menu.");
-
-            // Append those items that which events will be used in the egui
-            // event loop.
-            for elem in &app_struc.tray_icon_items {
-                tray_menu.append(elem).expect("Error creating the tray button");
-            }
+            let mut app_struc = Box::<MyApp>::default();
 
             #[cfg(not(any(
                 target_os = "linux",
@@ -98,12 +71,14 @@ fn main() -> Result<(), eframe::Error> {
             {
                 tray_c
                     .borrow_mut()
-                    .replace(TrayIconBuilder::new()
-                        .with_menu(Box::new(tray_menu))
-                        .with_tooltip("Some tray example text :-)")
-                        .with_icon(icon)
-                        .build()
-                        .unwrap() );
+                    .replace(create_tray_icon(icon, &menu_items));
+            }
+
+            // Add the ID list to the eframe data to being able to filter event
+            // sources
+            for item in &menu_items {
+                let id = item.id().clone();
+                app_struc.tray_icon_ids.push(id);
             }
 
             Ok(app_struc)
@@ -111,11 +86,45 @@ fn main() -> Result<(), eframe::Error> {
     )
 }
 
+// Create a tray icon with some custom settings, a menu, and some menu items
+fn create_tray_icon(icon: tray_icon::Icon, menu_items: &Vec<MenuItem>) -> TrayIcon {
+    // Create the tray menu
+    let tray_menu = Menu::new();
+
+    // Append those items that doesn't need to interact with the rest of
+    // the UI code
+    tray_menu.append_items(&[
+        &PredefinedMenuItem::about(
+            None,
+            Some(AboutMetadata {
+                name: Some("egui example".to_string()),
+                copyright: Some("Copyright egui example".to_string()),
+                ..Default::default()
+            }),
+        ),
+        &PredefinedMenuItem::separator(),
+    ]).expect("Error creating the tray icon menu.");
+
+    for item in menu_items {
+        tray_menu.append(item).unwrap();
+    }
+
+    // Create the tray icon and add the menu
+    let tray_icon = TrayIconBuilder::new()
+        .with_menu(Box::new(tray_menu))
+        .with_tooltip("Some tray example text :-)")
+        .with_icon(icon)
+        .build()
+        .unwrap();
+
+    return tray_icon;
+}
+
+
 struct MyApp {
     name: String,
     age: u32,
-    tray_icon_items: [tray_icon::menu::MenuItem; 1]
-    // Is better using a map to find a menuItem with its id
+    tray_icon_ids: Vec<tray_icon::menu::MenuId>
 }
 
 impl Default for MyApp {
@@ -123,7 +132,7 @@ impl Default for MyApp {
         Self {
             name: "Arthur".to_owned(),
             age: 42,
-            tray_icon_items: [MenuItem::new("Quit", true, None)]
+            tray_icon_ids: Vec::new()
         }
     }
 }
@@ -133,13 +142,13 @@ impl eframe::App for MyApp {
         // Those printing function of the tray event won't work when the window
         // isn't both openend and focused, as the egui event loop won't be running.
 
-        // if let Ok(event) = TrayIconEvent::receiver().try_recv() {
-        //     println!("tray event: {event:?}");
-        // }
+        if let Ok(event) = TrayIconEvent::receiver().try_recv() {
+            println!("tray event: {event:?}");
+        }
 
         if let Ok(event) = MenuEvent::receiver().try_recv() {
             println!("menu event: {event:?}");
-            if event.id == self.tray_icon_items[0].id() {
+            if event.id == self.tray_icon_ids[0] {
                 println!("Wanna close this?");
             }
         }

--- a/examples/egui.rs
+++ b/examples/egui.rs
@@ -9,23 +9,11 @@
 )))]
 
 use std::{cell::RefCell, rc::Rc};
-use winit::event_loop::EventLoop;
 use eframe::egui;
 use tray_icon::{
     menu::{AboutMetadata, Menu, MenuEvent, MenuItem, PredefinedMenuItem},
     TrayIconBuilder, TrayIconEvent,
 };
-
-enum UserTrayIconEvent {
-    TrayIconEvent(tray_icon::TrayIconEvent),
-    MenuEvent(tray_icon::menu::MenuEvent),
-}
-
-
-
-panic!("How to handle winit events inside or outside egui to have the tray events in parallel with the egui ui?");
-
-
 
 
 fn main() -> Result<(), eframe::Error> {
@@ -48,23 +36,6 @@ fn main() -> Result<(), eframe::Error> {
         &quit_i,
     ]).expect("Error creating the tray icon menu.");
 
-    // Create a winit event loop to handle the tray and tray menu events in
-    // parallel of any egui window (created or not)
-    let tray_event_loop = EventLoop::<UserTrayIconEvent>::with_user_event()
-    .build()
-    .expect("Error creating the winit event loop.");
-
-    // Those proxies send all those events generated in the tray to the previously
-    // made event loop
-    let proxy = tray_event_loop.create_proxy();
-    MenuEvent::set_event_handler(Some(move |event| {
-        proxy.send_event(UserTrayIconEvent::MenuEvent(event));
-    }));
-
-    let proxy = tray_event_loop.create_proxy();
-    TrayIconEvent::set_event_handler(Some(move |event| {
-        proxy.send_event(UserTrayIconEvent::TrayIconEvent(event));
-    }));
 
     // Since egui uses winit under the hood and doesn't use gtk on Linux, and we need gtk for
     // the tray icon to show up, we need to spawn a thread

--- a/examples/egui.rs
+++ b/examples/egui.rs
@@ -7,14 +7,64 @@
     target_os = "netbsd",
     target_os = "openbsd"
 )))]
-use std::{cell::RefCell, rc::Rc};
 
+use std::{cell::RefCell, rc::Rc};
+use winit::event_loop::EventLoop;
 use eframe::egui;
-use tray_icon::TrayIconBuilder;
+use tray_icon::{
+    menu::{AboutMetadata, Menu, MenuEvent, MenuItem, PredefinedMenuItem},
+    TrayIconBuilder, TrayIconEvent,
+};
+
+enum UserTrayIconEvent {
+    TrayIconEvent(tray_icon::TrayIconEvent),
+    MenuEvent(tray_icon::menu::MenuEvent),
+}
+
+
+
+panic!("How to handle winit events inside or outside egui to have the tray events in parallel with the egui ui?");
+
+
+
 
 fn main() -> Result<(), eframe::Error> {
     let path = concat!(env!("CARGO_MANIFEST_DIR"), "/examples/icon.png");
     let icon = load_icon(std::path::Path::new(path));
+
+    // Create the tray menu and add the desired items
+    let tray_menu = Menu::new();
+    let quit_i = MenuItem::new("Quit", true, None);
+    tray_menu.append_items(&[
+        &PredefinedMenuItem::about(
+            None,
+            Some(AboutMetadata {
+                name: Some("egui example".to_string()),
+                copyright: Some("Copyright egui example".to_string()),
+                ..Default::default()
+            }),
+        ),
+        &PredefinedMenuItem::separator(),
+        &quit_i,
+    ]).expect("Error creating the tray icon menu.");
+
+    // Create a winit event loop to handle the tray and tray menu events in
+    // parallel of any egui window (created or not)
+    let tray_event_loop = EventLoop::<UserTrayIconEvent>::with_user_event()
+    .build()
+    .expect("Error creating the winit event loop.");
+
+    // Those proxies send all those events generated in the tray to the previously
+    // made event loop
+    let proxy = tray_event_loop.create_proxy();
+    MenuEvent::set_event_handler(Some(move |event| {
+        proxy.send_event(UserTrayIconEvent::MenuEvent(event));
+    }));
+
+    let proxy = tray_event_loop.create_proxy();
+    TrayIconEvent::set_event_handler(Some(move |event| {
+        proxy.send_event(UserTrayIconEvent::TrayIconEvent(event));
+    }));
 
     // Since egui uses winit under the hood and doesn't use gtk on Linux, and we need gtk for
     // the tray icon to show up, we need to spawn a thread
@@ -27,11 +77,10 @@ fn main() -> Result<(), eframe::Error> {
         target_os = "openbsd"
     ))]
     std::thread::spawn(|| {
-        use tray_icon::menu::Menu;
-
         gtk::init().unwrap();
         let _tray_icon = TrayIconBuilder::new()
-            .with_menu(Box::new(Menu::new()))
+            .with_menu(Box::new(tray_menu))
+            .with_tooltip("Some tray example text :-)")
             .with_icon(icon)
             .build()
             .unwrap();
@@ -70,7 +119,12 @@ fn main() -> Result<(), eframe::Error> {
             {
                 tray_c
                     .borrow_mut()
-                    .replace(TrayIconBuilder::new().with_icon(icon).build().unwrap());
+                    .replace(TrayIconBuilder::new()
+                        .with_menu(Box::new(tray_menu))
+                        .with_tooltip("Some tray example text :-)")
+                        .with_icon(icon)
+                        .build()
+                        .unwrap() );
             }
             Ok(Box::<MyApp>::default())
         }),
@@ -93,12 +147,17 @@ impl Default for MyApp {
 
 impl eframe::App for MyApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
-        use tray_icon::TrayIconEvent;
-
+        // Those printing function of the tray event won't work when the window
+        // isn't both openend and focused, as the egui event loop won't be running.
         if let Ok(event) = TrayIconEvent::receiver().try_recv() {
             println!("tray event: {event:?}");
         }
 
+        if let Ok(event) = MenuEvent::receiver().try_recv() {
+            println!("menu event: {event:?}");
+        }
+
+        // Design of the egui window
         egui::CentralPanel::default().show(ctx, |ui| {
             ui.heading("My egui Application");
             ui.horizontal(|ui| {

--- a/examples/egui.rs
+++ b/examples/egui.rs
@@ -128,32 +128,6 @@ impl Default for MyApp {
     }
 }
 
-// impl MyApp {
-//     fn new(_cc: &eframe::CreationContext<'_>) -> Self {
-//         let app_struc = Self::default();
-
-//         //let quit_i = MenuItem::new("Quit", true, None);
-//         tray_menu.append_items(&[
-//             &PredefinedMenuItem::about(
-//                 None,
-//                 Some(AboutMetadata {
-//                     name: Some("egui example".to_string()),
-//                     copyright: Some("Copyright egui example".to_string()),
-//                     ..Default::default()
-//                 }),
-//             ),
-//             &PredefinedMenuItem::separator(),
-//             //&quit_i,
-//         ]).expect("Error creating the tray icon menu.");
-
-//         for elem in &app_struc.tray_icon_items {
-//             tray_menu.append(elem);
-//         }
-
-//         return app_struc;
-//     }
-// }
-
 impl eframe::App for MyApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
         // Those printing function of the tray event won't work when the window

--- a/examples/egui.rs
+++ b/examples/egui.rs
@@ -10,16 +10,11 @@
 use std::{cell::RefCell, rc::Rc};
 
 use eframe::egui;
-use tray_icon::{
-    TrayIcon, TrayIconBuilder, TrayIconEvent,
-    menu::{AboutMetadata, Menu, MenuEvent, MenuItem, PredefinedMenuItem}
-};
-
+use tray_icon::TrayIconBuilder;
 
 fn main() -> Result<(), eframe::Error> {
     let path = concat!(env!("CARGO_MANIFEST_DIR"), "/examples/icon.png");
     let icon = load_icon(std::path::Path::new(path));
-    let menu_items = vec![MenuItem::new("Exit", true, None)];
 
     // Since egui uses winit under the hood and doesn't use gtk on Linux, and we need gtk for
     // the tray icon to show up, we need to spawn a thread
@@ -32,8 +27,14 @@ fn main() -> Result<(), eframe::Error> {
         target_os = "openbsd"
     ))]
     std::thread::spawn(|| {
+        use tray_icon::menu::Menu;
+
         gtk::init().unwrap();
-        let _tray_icon = create_tray_icon(icon, &menu_items);
+        let _tray_icon = TrayIconBuilder::new()
+            .with_menu(Box::new(Menu::new()))
+            .with_icon(icon)
+            .build()
+            .unwrap();
 
         gtk::main();
     });
@@ -59,8 +60,6 @@ fn main() -> Result<(), eframe::Error> {
         "My egui App",
         eframe::NativeOptions::default(),
         Box::new(move |_cc| {
-            let mut app_struc = Box::<MyApp>::default();
-
             #[cfg(not(any(
                 target_os = "linux",
                 target_os = "dragonfly",
@@ -71,60 +70,16 @@ fn main() -> Result<(), eframe::Error> {
             {
                 tray_c
                     .borrow_mut()
-                    .replace(create_tray_icon(icon, &menu_items));
+                    .replace(TrayIconBuilder::new().with_icon(icon).build().unwrap());
             }
-
-            // Add the ID list to the eframe data to being able to filter event
-            // sources
-            for item in &menu_items {
-                let id = item.id().clone();
-                app_struc.tray_icon_ids.push(id);
-            }
-
-            Ok(app_struc)
+            Ok(Box::<MyApp>::default())
         }),
     )
 }
 
-// Create a tray icon with some custom settings, a menu, and some menu items
-fn create_tray_icon(icon: tray_icon::Icon, menu_items: &Vec<MenuItem>) -> TrayIcon {
-    // Create the tray menu
-    let tray_menu = Menu::new();
-
-    // Append those items that doesn't need to interact with the rest of
-    // the UI code
-    tray_menu.append_items(&[
-        &PredefinedMenuItem::about(
-            None,
-            Some(AboutMetadata {
-                name: Some("egui example".to_string()),
-                copyright: Some("Copyright egui example".to_string()),
-                ..Default::default()
-            }),
-        ),
-        &PredefinedMenuItem::separator(),
-    ]).expect("Error creating the tray icon menu.");
-
-    for item in menu_items {
-        tray_menu.append(item).unwrap();
-    }
-
-    // Create the tray icon and add the menu
-    let tray_icon = TrayIconBuilder::new()
-        .with_menu(Box::new(tray_menu))
-        .with_tooltip("Some tray example text :-)")
-        .with_icon(icon)
-        .build()
-        .unwrap();
-
-    return tray_icon;
-}
-
-
 struct MyApp {
     name: String,
     age: u32,
-    tray_icon_ids: Vec<tray_icon::menu::MenuId>
 }
 
 impl Default for MyApp {
@@ -132,28 +87,18 @@ impl Default for MyApp {
         Self {
             name: "Arthur".to_owned(),
             age: 42,
-            tray_icon_ids: Vec::new()
         }
     }
 }
 
 impl eframe::App for MyApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
-        // Those printing function of the tray event won't work when the window
-        // isn't both openend and focused, as the egui event loop won't be running.
+        use tray_icon::TrayIconEvent;
 
         if let Ok(event) = TrayIconEvent::receiver().try_recv() {
             println!("tray event: {event:?}");
         }
 
-        if let Ok(event) = MenuEvent::receiver().try_recv() {
-            println!("menu event: {event:?}");
-            if event.id == self.tray_icon_ids[0] {
-                println!("Wanna close this?");
-            }
-        }
-
-        // Design of the egui window
         egui::CentralPanel::default().show(ctx, |ui| {
             ui.heading("My egui Application");
             ui.horizontal(|ui| {

--- a/examples/egui.rs
+++ b/examples/egui.rs
@@ -12,30 +12,13 @@ use std::{cell::RefCell, rc::Rc};
 use eframe::egui;
 use tray_icon::{
     menu::{AboutMetadata, Menu, MenuEvent, MenuItem, PredefinedMenuItem},
-    TrayIconBuilder, TrayIconEvent,
+    TrayIconBuilder
 };
 
 
 fn main() -> Result<(), eframe::Error> {
     let path = concat!(env!("CARGO_MANIFEST_DIR"), "/examples/icon.png");
     let icon = load_icon(std::path::Path::new(path));
-
-    // Create the tray menu and add the desired items
-    let tray_menu = Menu::new();
-    let quit_i = MenuItem::new("Quit", true, None);
-    tray_menu.append_items(&[
-        &PredefinedMenuItem::about(
-            None,
-            Some(AboutMetadata {
-                name: Some("egui example".to_string()),
-                copyright: Some("Copyright egui example".to_string()),
-                ..Default::default()
-            }),
-        ),
-        &PredefinedMenuItem::separator(),
-        &quit_i,
-    ]).expect("Error creating the tray icon menu.");
-
 
     // Since egui uses winit under the hood and doesn't use gtk on Linux, and we need gtk for
     // the tray icon to show up, we need to spawn a thread
@@ -80,6 +63,31 @@ fn main() -> Result<(), eframe::Error> {
         "My egui App",
         eframe::NativeOptions::default(),
         Box::new(move |_cc| {
+            let app_struc = Box::<MyApp>::default();
+
+            // Create the tray menu and add the desired items
+            let tray_menu = Menu::new();
+
+            // Append those items that doesn't need to interact with the rest of
+            // the UI code
+            tray_menu.append_items(&[
+                &PredefinedMenuItem::about(
+                    None,
+                    Some(AboutMetadata {
+                        name: Some("egui example".to_string()),
+                        copyright: Some("Copyright egui example".to_string()),
+                        ..Default::default()
+                    }),
+                ),
+                &PredefinedMenuItem::separator(),
+            ]).expect("Error creating the tray icon menu.");
+
+            // Append those items that which events will be used in the egui
+            // event loop.
+            for elem in &app_struc.tray_icon_items {
+                tray_menu.append(elem).expect("Error creating the tray button");
+            }
+
             #[cfg(not(any(
                 target_os = "linux",
                 target_os = "dragonfly",
@@ -97,7 +105,8 @@ fn main() -> Result<(), eframe::Error> {
                         .build()
                         .unwrap() );
             }
-            Ok(Box::<MyApp>::default())
+
+            Ok(app_struc)
         }),
     )
 }
@@ -105,6 +114,8 @@ fn main() -> Result<(), eframe::Error> {
 struct MyApp {
     name: String,
     age: u32,
+    tray_icon_items: [tray_icon::menu::MenuItem; 1]
+    // Is better using a map to find a menuItem with its id
 }
 
 impl Default for MyApp {
@@ -112,20 +123,51 @@ impl Default for MyApp {
         Self {
             name: "Arthur".to_owned(),
             age: 42,
+            tray_icon_items: [MenuItem::new("Quit", true, None)]
         }
     }
 }
+
+// impl MyApp {
+//     fn new(_cc: &eframe::CreationContext<'_>) -> Self {
+//         let app_struc = Self::default();
+
+//         //let quit_i = MenuItem::new("Quit", true, None);
+//         tray_menu.append_items(&[
+//             &PredefinedMenuItem::about(
+//                 None,
+//                 Some(AboutMetadata {
+//                     name: Some("egui example".to_string()),
+//                     copyright: Some("Copyright egui example".to_string()),
+//                     ..Default::default()
+//                 }),
+//             ),
+//             &PredefinedMenuItem::separator(),
+//             //&quit_i,
+//         ]).expect("Error creating the tray icon menu.");
+
+//         for elem in &app_struc.tray_icon_items {
+//             tray_menu.append(elem);
+//         }
+
+//         return app_struc;
+//     }
+// }
 
 impl eframe::App for MyApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
         // Those printing function of the tray event won't work when the window
         // isn't both openend and focused, as the egui event loop won't be running.
-        if let Ok(event) = TrayIconEvent::receiver().try_recv() {
-            println!("tray event: {event:?}");
-        }
+
+        // if let Ok(event) = TrayIconEvent::receiver().try_recv() {
+        //     println!("tray event: {event:?}");
+        // }
 
         if let Ok(event) = MenuEvent::receiver().try_recv() {
             println!("menu event: {event:?}");
+            if event.id == self.tray_icon_items[0].id() {
+                println!("Wanna close this?");
+            }
         }
 
         // Design of the egui window

--- a/examples/egui_parallel.rs
+++ b/examples/egui_parallel.rs
@@ -54,6 +54,9 @@ fn main() -> Result<(), eframe::Error> {
 
     // Thread that will process all the menu item events made by the user. This
     // thread will be destroyed when the main thread ends by design.
+    //
+    // The function 'recv()' is a locking one, and that means the loop will get
+    // stuck until some event is generated, then it will continue running.
     std::thread::spawn(move || {
         let ids = menu_items_id;
         loop {
@@ -84,7 +87,7 @@ fn create_tray_icon(icon: tray_icon::Icon, menu_items: Vec<MenuItem>) -> TrayIco
     // Create the tray menu
     let tray_menu = Menu::new();
 
-    // Append those items that doesn't need to interact with the rest of
+    // Append those static items that doesn't need to interact with the rest of
     // the UI code
     tray_menu.append_items(&[
         &PredefinedMenuItem::about(
@@ -98,6 +101,7 @@ fn create_tray_icon(icon: tray_icon::Icon, menu_items: Vec<MenuItem>) -> TrayIco
         &PredefinedMenuItem::separator(),
     ]).expect("Error creating the tray icon menu.");
 
+    // Append items that will be interacting with egui in some way or another.
     for item in menu_items {
         tray_menu.append(&item).unwrap();
     }
@@ -133,10 +137,16 @@ impl eframe::App for MyApp {
         // Those printing function of the tray event won't work when the window
         // isn't both openend and focused, as the egui event loop won't be running.
 
+        // Print tray icon events.
         if let Ok(event) = TrayIconEvent::receiver().try_recv() {
             println!("tray event: {event:?}");
         }
 
+        // Print tray icon menu events.
+        // Those events already received by the parrallel thread won't be here,
+        // and knowing this frame generating thread is locked to 60 FPS (or the
+        // screen frequency), this is a lot slower, and rarely will get any of
+        // those events.
         if let Ok(event) = MenuEvent::receiver().try_recv() {
             println!("menu event: {event:?}");
         }

--- a/examples/egui_parallel.rs
+++ b/examples/egui_parallel.rs
@@ -1,11 +1,11 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // hide console window on Windows in release
 
-#[cfg(not(any(
-        target_os = "linux",
-        target_os = "dragonfly",
-        target_os = "freebsd",
-        target_os = "netbsd",
-        target_os = "openbsd"
+ #[cfg(not(any(
+    target_os = "linux",
+    target_os = "dragonfly",
+    target_os = "freebsd",
+    target_os = "netbsd",
+    target_os = "openbsd"
 )))]
 use std::{cell::RefCell, rc::Rc};
 
@@ -22,11 +22,16 @@ fn main() -> Result<(), eframe::Error> {
     let path = concat!(env!("CARGO_MANIFEST_DIR"), "/examples/icon.png");
     let icon = load_icon(std::path::Path::new(path));
 
+    // This might not be the most elegant way to avoid repeating the same code
+    // in the Linux/Unix part and the Windows one, but I don't know a better way
+    // to do it in Rust.
     macro_rules! generate_menu_items {
         () => (vec![MenuItem::new("Quit", true, None)])
     }
 
-    // This is to provide the items ids to the event processing thread.
+    // Vector storing the IDs of the menu items that would interact with both
+    // the egui event loop in this thread, and the custom event processing loop
+    // in another thread.
     let menu_items_id = Arc::new(Mutex::new(Vec::<MenuId>::new()));
 
     // In the case of having more than one item to process, this could be a
@@ -34,7 +39,6 @@ fn main() -> Result<(), eframe::Error> {
     enum MenuItemsCmd {
         Exit = 0,
     }
-
 
     // Since egui uses winit under the hood and doesn't use gtk on Linux, and we
     // need gtk for the tray icon to show up, we need to spawn a thread where we
@@ -93,6 +97,8 @@ fn main() -> Result<(), eframe::Error> {
     )))]
     let menu_items;
 
+    // Generate the menu items in Windows, get their IDs, and store them in a
+    // multi-threaded safe way.
     #[cfg(not(any(
         target_os = "linux",
         target_os = "dragonfly",
@@ -112,11 +118,12 @@ fn main() -> Result<(), eframe::Error> {
         }
     }
 
-    // Thread that will process all the menu item events made by the user. This
-    // thread will be destroyed when the main thread ends by design.
+    // Process all the menu item events made by the user in a separate thread.
+    //
+    // This thread will be destroyed when the main thread ends by design.
     //
     // The function 'recv()' is a locking one, and that means the loop will get
-    // stuck until some event is generated, then it will continue running.
+    // stuck until some event is generated.
     let ids_loop_thread = Arc::clone(&menu_items_id);
     std::thread::spawn(move || {
         loop {
@@ -160,6 +167,7 @@ fn main() -> Result<(), eframe::Error> {
 }
 
 
+// Create the tray menu, add items to it, and create the tray icon that will have them.
 fn create_tray_icon(icon: tray_icon::Icon, menu_items: &Vec<MenuItem>) -> TrayIcon {
     // Create the tray menu
     let tray_menu = Menu::new();
@@ -214,7 +222,7 @@ impl eframe::App for MyApp {
         // Those printing function of the tray event won't work when the window
         // isn't both openend and focused, as the egui event loop won't be running.
 
-        // Print tray icon events.
+        // Print tray icon events. This is not supported in Linux.
         if let Ok(event) = TrayIconEvent::receiver().try_recv() {
             println!("tray event: {event:?}");
         }

--- a/examples/egui_parallel.rs
+++ b/examples/egui_parallel.rs
@@ -1,5 +1,14 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // hide console window on Windows in release
 
+#[cfg(not(any(
+        target_os = "linux",
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_os = "openbsd"
+)))]
+use std::{cell::RefCell, rc::Rc};
+
 use std::process::exit;
 use std::sync::{Arc, Mutex};
 use eframe::egui;
@@ -56,6 +65,7 @@ fn main() -> Result<(), eframe::Error> {
         });
     }
 
+
     #[cfg(not(any(
         target_os = "linux",
         target_os = "dragonfly",
@@ -63,7 +73,44 @@ fn main() -> Result<(), eframe::Error> {
         target_os = "netbsd",
         target_os = "openbsd"
     )))]
-    let _tray_icon = create_tray_icon(icon, menu_items);
+    let mut _tray_icon = Rc::new(RefCell::new(None));
+
+    #[cfg(not(any(
+        target_os = "linux",
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_os = "openbsd"
+    )))]
+    let tray_c = _tray_icon.clone();
+
+    #[cfg(not(any(
+        target_os = "linux",
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_os = "openbsd"
+    )))]
+    let menu_items;
+
+    #[cfg(not(any(
+        target_os = "linux",
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_os = "openbsd"
+    )))] {
+        menu_items = generate_menu_items!();
+
+        let ids_win_thread = Arc::clone(&menu_items_id);
+
+        {
+            let mut ids = ids_win_thread.lock().unwrap();
+            for item in &menu_items {
+                ids.push(item.id().clone());
+            }
+        }
+    }
 
     // Thread that will process all the menu item events made by the user. This
     // thread will be destroyed when the main thread ends by design.
@@ -75,11 +122,9 @@ fn main() -> Result<(), eframe::Error> {
         loop {
             if let Ok(event) = MenuEvent::receiver().recv() {
                 let ids = ids_loop_thread.lock().unwrap();
-                
-                if ids.len() < 1 {
-                    break
-                };
-                
+
+                assert!((ids.len() > 0), "No IDs found to process in parrallel!");
+
                 if event.id == ids[MenuItemsCmd::Exit as usize] {
                     println!("Exit pressed!");
                     exit(0);
@@ -93,6 +138,19 @@ fn main() -> Result<(), eframe::Error> {
         eframe::NativeOptions::default(),
         Box::new(move |_cc| {
             let app_struc = Box::<MyApp>::default();
+
+            #[cfg(not(any(
+                target_os = "linux",
+                target_os = "dragonfly",
+                target_os = "freebsd",
+                target_os = "netbsd",
+                target_os = "openbsd"
+            )))]
+            {
+                tray_c
+                    .borrow_mut()
+                    .replace(create_tray_icon(icon, &menu_items));
+            }
 
             Ok(app_struc)
         }),

--- a/examples/egui_parallel.rs
+++ b/examples/egui_parallel.rs
@@ -1,9 +1,10 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // hide console window on Windows in release
 
 use std::process::exit;
+use std::sync::{Arc, Mutex};
 use eframe::egui;
 use tray_icon::{
-    menu::{AboutMetadata, Menu, MenuEvent, MenuItem, PredefinedMenuItem},
+    menu::{AboutMetadata, Menu, MenuEvent, MenuId, MenuItem, PredefinedMenuItem},
     TrayIconEvent, TrayIconBuilder, TrayIcon
 };
 
@@ -12,19 +13,19 @@ fn main() -> Result<(), eframe::Error> {
     let path = concat!(env!("CARGO_MANIFEST_DIR"), "/examples/icon.png");
     let icon = load_icon(std::path::Path::new(path));
 
-    let menu_items = vec![MenuItem::new("Quit", true, None)];
+    macro_rules! generate_menu_items {
+        () => (vec![MenuItem::new("Quit", true, None)])
+    }
 
     // This is to provide the items ids to the event processing thread.
-    let mut menu_items_id = Vec::new();
-    for item in &menu_items {
-        menu_items_id.push(item.id().clone());
-    }
+    let menu_items_id = Arc::new(Mutex::new(Vec::<MenuId>::new()));
 
     // In the case of having more than one item to process, this could be a
     // simple way to having a distinguish between items.
     enum MenuItemsCmd {
         Exit = 0,
     }
+
 
     // Since egui uses winit under the hood and doesn't use gtk on Linux, and we
     // need gtk for the tray icon to show up, we need to spawn a thread where we
@@ -35,13 +36,25 @@ fn main() -> Result<(), eframe::Error> {
         target_os = "freebsd",
         target_os = "netbsd",
         target_os = "openbsd"
-    ))]
-    std::thread::spawn(|| {
-        gtk::init().unwrap();
-        let _tray_icon = create_tray_icon(icon, menu_items);
+    ))]{
+        let ids_gtk_thread = Arc::clone(&menu_items_id);
 
-        gtk::main();
-    });
+        std::thread::spawn(move || {
+            gtk::init().unwrap();
+
+            let menu_items = generate_menu_items!();
+            let _tray_icon = create_tray_icon(icon, &menu_items);
+
+            {
+                let mut ids = ids_gtk_thread.lock().unwrap();
+                for item in &menu_items {
+                    ids.push(item.id().clone());
+                }
+            }
+
+            gtk::main();
+        });
+    }
 
     #[cfg(not(any(
         target_os = "linux",
@@ -57,10 +70,16 @@ fn main() -> Result<(), eframe::Error> {
     //
     // The function 'recv()' is a locking one, and that means the loop will get
     // stuck until some event is generated, then it will continue running.
+    let ids_loop_thread = Arc::clone(&menu_items_id);
     std::thread::spawn(move || {
-        let ids = menu_items_id;
         loop {
             if let Ok(event) = MenuEvent::receiver().recv() {
+                let ids = ids_loop_thread.lock().unwrap();
+                
+                if ids.len() < 1 {
+                    break
+                };
+                
                 if event.id == ids[MenuItemsCmd::Exit as usize] {
                     println!("Exit pressed!");
                     exit(0);
@@ -83,7 +102,7 @@ fn main() -> Result<(), eframe::Error> {
 }
 
 
-fn create_tray_icon(icon: tray_icon::Icon, menu_items: Vec<MenuItem>) -> TrayIcon {
+fn create_tray_icon(icon: tray_icon::Icon, menu_items: &Vec<MenuItem>) -> TrayIcon {
     // Create the tray menu
     let tray_menu = Menu::new();
 
@@ -103,7 +122,7 @@ fn create_tray_icon(icon: tray_icon::Icon, menu_items: Vec<MenuItem>) -> TrayIco
 
     // Append items that will be interacting with egui in some way or another.
     for item in menu_items {
-        tray_menu.append(&item).unwrap();
+        tray_menu.append(item).unwrap();
     }
 
     // Create the tray icon and add the menu

--- a/examples/egui_parallel.rs
+++ b/examples/egui_parallel.rs
@@ -1,0 +1,171 @@
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // hide console window on Windows in release
+
+use std::process::exit;
+use eframe::egui;
+use tray_icon::{
+    menu::{AboutMetadata, Menu, MenuEvent, MenuItem, PredefinedMenuItem},
+    TrayIconEvent, TrayIconBuilder, TrayIcon
+};
+
+
+fn main() -> Result<(), eframe::Error> {
+    let path = concat!(env!("CARGO_MANIFEST_DIR"), "/examples/icon.png");
+    let icon = load_icon(std::path::Path::new(path));
+
+    let menu_items = vec![MenuItem::new("Quit", true, None)];
+
+    // This is to provide the items ids to the event processing thread.
+    let mut menu_items_id = Vec::new();
+    for item in &menu_items {
+        menu_items_id.push(item.id().clone());
+    }
+
+    // In the case of having more than one item to process, this could be a
+    // simple way to having a distinguish between items.
+    enum MenuItemsCmd {
+        Exit = 0,
+    }
+
+    // Since egui uses winit under the hood and doesn't use gtk on Linux, and we
+    // need gtk for the tray icon to show up, we need to spawn a thread where we
+    // initialize gtk and create the tray_icon
+    #[cfg(any(
+        target_os = "linux",
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_os = "openbsd"
+    ))]
+    std::thread::spawn(|| {
+        gtk::init().unwrap();
+        let _tray_icon = create_tray_icon(icon, menu_items);
+
+        gtk::main();
+    });
+
+    #[cfg(not(any(
+        target_os = "linux",
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_os = "openbsd"
+    )))]
+    let _tray_icon = create_tray_icon(icon, menu_items);
+
+    // Thread that will process all the menu item events made by the user. This
+    // thread will be destroyed when the main thread ends by design.
+    std::thread::spawn(move || {
+        let ids = menu_items_id;
+        loop {
+            if let Ok(event) = MenuEvent::receiver().recv() {
+                if event.id == ids[MenuItemsCmd::Exit as usize] {
+                    println!("Exit pressed!");
+                    exit(0);
+                }
+            }
+        }
+    });
+
+    let eframe_run_result = eframe::run_native(
+        "My egui App",
+        eframe::NativeOptions::default(),
+        Box::new(move |_cc| {
+            let app_struc = Box::<MyApp>::default();
+
+            Ok(app_struc)
+        }),
+    );
+
+    return eframe_run_result;
+}
+
+
+fn create_tray_icon(icon: tray_icon::Icon, menu_items: Vec<MenuItem>) -> TrayIcon {
+    // Create the tray menu
+    let tray_menu = Menu::new();
+
+    // Append those items that doesn't need to interact with the rest of
+    // the UI code
+    tray_menu.append_items(&[
+        &PredefinedMenuItem::about(
+            None,
+            Some(AboutMetadata {
+                name: Some("egui example".to_string()),
+                copyright: Some("Copyright egui example".to_string()),
+                ..Default::default()
+            }),
+        ),
+        &PredefinedMenuItem::separator(),
+    ]).expect("Error creating the tray icon menu.");
+
+    for item in menu_items {
+        tray_menu.append(&item).unwrap();
+    }
+
+    // Create the tray icon and add the menu
+    let tray_icon = TrayIconBuilder::new()
+        .with_menu(Box::new(tray_menu))
+        .with_tooltip("Some tray example text :-)")
+        .with_icon(icon)
+        .build()
+        .unwrap();
+
+    return tray_icon;
+}
+
+
+struct MyApp {
+    name: String,
+    age: u32,
+}
+
+impl Default for MyApp {
+    fn default() -> Self {
+        Self {
+            name: "Arthur".to_owned(),
+            age: 42,
+        }
+    }
+}
+
+impl eframe::App for MyApp {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        // Those printing function of the tray event won't work when the window
+        // isn't both openend and focused, as the egui event loop won't be running.
+
+        if let Ok(event) = TrayIconEvent::receiver().try_recv() {
+            println!("tray event: {event:?}");
+        }
+
+        if let Ok(event) = MenuEvent::receiver().try_recv() {
+            println!("menu event: {event:?}");
+        }
+
+        // Design of the egui window
+        egui::CentralPanel::default().show(ctx, |ui| {
+            ui.heading("My egui Application");
+            ui.horizontal(|ui| {
+                let name_label = ui.label("Your name: ");
+                ui.text_edit_singleline(&mut self.name)
+                    .labelled_by(name_label.id);
+            });
+            ui.add(egui::Slider::new(&mut self.age, 0..=120).text("age"));
+            if ui.button("Click each year").clicked() {
+                self.age += 1;
+            }
+            ui.label(format!("Hello '{}', age {}", self.name, self.age));
+        });
+    }
+}
+
+fn load_icon(path: &std::path::Path) -> tray_icon::Icon {
+    let (icon_rgba, icon_width, icon_height) = {
+        let image = image::open(path)
+            .expect("Failed to open icon path")
+            .into_rgba8();
+        let (width, height) = image.dimensions();
+        let rgba = image.into_raw();
+        (rgba, width, height)
+    };
+    tray_icon::Icon::from_rgba(icon_rgba, icon_width, icon_height).expect("Failed to open icon")
+}


### PR DESCRIPTION
Hi there!

I tested the egui example you have here to learn how this library works, and I noticed how when the window isn't focused or it is minimized no event is processed. Those events are processed in the same function that run when it needs to update window frames, so it's logic how if it doesn't need to update those frames (the condition I described previously), it won't process those events.

Anyway, I got that example and edited it to process those events in parallel, in another thread, making it work even when no egui frames isn't generated. I have some programming experience, and I know about concurrent programming, but I'm not experience enough in Rust, so if I made some mistake or done something not in "the Rust way" (I come from the C/C++ btw), please feel free to correct me.

I wanted to add some intercommunication between egui and the event-processing thread, but I found it maybe too complete for just a simple working example. If you find it interesting to be added, I would do it! :)

Thank you for your time!