### PR TITLE
fix(macos): flip the tray rect in points, not display pixels

### DIFF
--- a/.changes/fix-macos-tray-rect-points.md
+++ b/.changes/fix-macos-tray-rect-points.md
@@ -1,0 +1,5 @@
+---
+"tray-icon": patch
+---
+
+On macOS, the screen-coordinate flip used `CGDisplayPixelsHigh` where the incoming values are Cocoa points, skewing the reported tray icon rect and cursor position by the scale factor whenever the main display is Retina. Flip against the main display's bounds height in points instead.

--- a/src/platform_impl/macos/mod.rs
+++ b/src/platform_impl/macos/mod.rs
@@ -12,7 +12,7 @@ use objc2_app_kit::{
     NSTrackingAreaOptions, NSVariableStatusItemLength, NSView, NSWindow,
 };
 use objc2_core_foundation::{CGPoint, CGRect, CGSize};
-use objc2_core_graphics::{CGDisplayPixelsHigh, CGMainDisplayID};
+use objc2_core_graphics::{CGDisplayBounds, CGMainDisplayID};
 use objc2_foundation::{MainThreadMarker, NSData, NSSize, NSString};
 
 pub(crate) use self::icon::PlatformIcon;
@@ -607,6 +607,11 @@ struct MouseClickEvent {
 ///
 /// This conversion happens to be symmetric, so we only need this one function
 /// to convert between the two coordinate systems.
+///
+/// The flip must happen in points, the unit of the incoming `NSWindow` and
+/// `NSEvent` values: `CGDisplayBounds` is in points, while
+/// `CGDisplayPixelsHigh` is not on a Retina main display, which skewed every
+/// tray rect and cursor position by the scale factor.
 fn flip_window_screen_coordinates(y: f64) -> f64 {
-    unsafe { CGDisplayPixelsHigh(CGMainDisplayID()) as f64 - y }
+    unsafe { CGDisplayBounds(CGMainDisplayID()).size.height - y }
 }


### PR DESCRIPTION
flip_window_screen_coordinates subtracted Cocoa point values from CGDisplayPixelsHigh, off by the scale factor on a Retina main display; every tray rect and tray cursor position inherited the skew (tauri-apps/plugins-workspace#724). Flip against the main display's bounds height, which is in points like the incoming values. Verified live: tray rects now come back correct on both a 1x and a 2x menu bar. Context: https://github.com/tauri-apps/tauri/issues/7890#issuecomment-5012641117