### PR TITLE
fix(macos): defer NSStatusItem teardown to the main queue when dropped off the main thread

### DIFF
--- a/.changes/macos-main-thread-teardown.md
+++ b/.changes/macos-main-thread-teardown.md
@@ -1,0 +1,5 @@
+---
+"tray-icon": patch
+---
+
+On macOS, dropping the last `TrayIcon` handle off the main thread now defers `NSStatusItem` teardown to the main dispatch queue instead of crashing with a BoardServices main-queue assertion (`EXC_BREAKPOINT`) on macOS 26.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -857,6 +857,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
 
 [[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.8.0",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3535,6 +3544,7 @@ version = "0.24.2"
 dependencies = [
  "crossbeam-channel",
  "dirs",
+ "dispatch2",
  "eframe",
  "gtk",
  "image",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ dirs = "6"
 gtk = "0.18"
 
 [target."cfg(target_os = \"macos\")".dependencies]
+dispatch2 = { version = "0.3", default-features = false, features = ["std"] }
 objc2 = "0.6"
 objc2-core-graphics = { version = "0.3", default-features = false, features = [
   "std",

--- a/src/platform_impl/macos/mod.rs
+++ b/src/platform_impl/macos/mod.rs
@@ -5,6 +5,7 @@
 mod icon;
 use std::cell::{Cell, RefCell};
 
+use dispatch2::DispatchQueue;
 use objc2::rc::Retained;
 use objc2::{define_class, msg_send, AllocAnyThread, DeclaredClass, Message};
 use objc2_app_kit::{
@@ -100,16 +101,32 @@ impl TrayIcon {
     }
 
     fn remove(&mut self) {
-        if let (Some(ns_status_item), Some(tray_target)) = (&self.ns_status_item, &self.tray_target)
-        {
-            unsafe {
-                NSStatusBar::systemStatusBar().removeStatusItem(ns_status_item);
-                tray_target.removeFromSuperview();
-            }
+        let ns_status_item = self.ns_status_item.take();
+        let tray_target = self.tray_target.take();
+        if ns_status_item.is_none() && tray_target.is_none() {
+            return;
         }
 
-        self.ns_status_item = None;
-        self.tray_target = None;
+        // A fresh marker, never `self.mtm`: this may run on any thread, and a marker stored at
+        // construction time says nothing about the current one.
+        if MainThreadMarker::new().is_some() {
+            unsafe { remove_status_item(ns_status_item.as_deref(), tray_target.as_deref()) };
+            return;
+        }
+
+        #[cfg(debug_assertions)]
+        eprintln!(
+            "tray-icon: TrayIcon removed off the main thread, deferring NSStatusItem teardown to the main queue"
+        );
+
+        let teardown = MainThreadTeardown {
+            ns_status_item,
+            tray_target,
+        };
+        DispatchQueue::main().exec_async(move || {
+            // SAFETY: the main dispatch queue runs this closure on the main thread.
+            unsafe { teardown.run() };
+        });
     }
 
     pub fn set_icon(&mut self, icon: Option<Icon>) -> crate::Result<()> {
@@ -277,6 +294,52 @@ impl TrayIcon {
 impl Drop for TrayIcon {
     fn drop(&mut self) {
         self.remove()
+    }
+}
+
+/// Carries the AppKit handles of a tray icon to the main queue for teardown.
+struct MainThreadTeardown {
+    ns_status_item: Option<Retained<NSStatusItem>>,
+    tray_target: Option<Retained<TrayTarget>>,
+}
+
+// SAFETY: `Retained<NSStatusItem>` and `Retained<TrayTarget>` are `!Send` because AppKit
+// requires them to be used and released on the main thread. The only value of this type is
+// moved directly into a closure submitted to the main dispatch queue, so it is never touched
+// off the main thread — including its final release, which happens when that closure drops it.
+//
+// The closure must consume the whole struct via `run`, never its fields: under edition 2021
+// disjoint capture, touching the fields would capture the `!Send` `Retained`s individually and
+// this `Send` impl would no longer apply.
+unsafe impl Send for MainThreadTeardown {}
+
+impl MainThreadTeardown {
+    /// # Safety
+    ///
+    /// Must be called on the main thread.
+    unsafe fn run(self) {
+        unsafe { remove_status_item(self.ns_status_item.as_deref(), self.tray_target.as_deref()) };
+    }
+}
+
+/// Detaches the status item and its target view from the status bar.
+///
+/// # Safety
+///
+/// Must be called on the main thread. On macOS 26 `NSStatusItem`s are scene-backed, and
+/// `-[NSStatusBar removeStatusItem:]` trips a BoardServices main-queue barrier assertion
+/// (`EXC_BREAKPOINT`) when it runs anywhere else.
+unsafe fn remove_status_item(
+    ns_status_item: Option<&NSStatusItem>,
+    tray_target: Option<&TrayTarget>,
+) {
+    unsafe {
+        if let Some(ns_status_item) = ns_status_item {
+            NSStatusBar::systemStatusBar().removeStatusItem(ns_status_item);
+        }
+        if let Some(tray_target) = tray_target {
+            tray_target.removeFromSuperview();
+        }
     }
 }
 


### PR DESCRIPTION

Fixes #350

## What

`remove()` (called from `Drop`) invoked `-[NSStatusBar removeStatusItem:]` on whatever thread dropped the last `TrayIcon` handle. On macOS 26 that trips a BoardServices main-queue assertion and kills the process — full analysis, production crash data, and a minimal repro in #350.

## How

- `remove()` checks a **fresh** `MainThreadMarker::new()` — never the stored `self.mtm`, which says nothing about the current thread.
- On the main thread: teardown runs inline, exactly as before.
- Off the main thread: the retained `NSStatusItem`/`TrayTarget` move into a `MainThreadTeardown` carrier released on the main queue via `dispatch2::DispatchQueue::main().exec_async`. Debug builds print a notice so off-main drops stay visible in development (`debug_assert!` was avoided: `remove()` runs inside `Drop`, and panicking during unwinding aborts).

**Why `unsafe impl Send` on the carrier is sound:** the only value is moved directly into a closure submitted to the main queue, so it is never touched — or released — off the main thread. The closure consumes the struct via `run()` rather than its fields, so edition-2021 disjoint capture can't split out the `!Send` `Retained`s and sidestep the impl (documented at the impl site).

## Dependency

Adds `dispatch2` (macOS-only, `default-features = false`). It's where objc2's run-on-main machinery lives; `exec_async` lowers to bare `dispatch_async_f`, no `block2` needed.

## Testing

- `cargo check` / `clippy --all-targets -- -D warnings` / `cargo test` pass on `dev` + this change (macOS, aarch64).
- Runtime-verified with the [repro from #350](https://github.com/ahonn/tray-icon-offmain-drop-repro): against `dev` it crashes with the exact production signature; with this change it prints the deferral notice, the main queue removes the item, and the process exits cleanly.
- Shipping in production in Badgeify via our fork.

Scope: hardens the drop-side AppKit hazard only; the `Rc` refcount race from `unsafe` cross-thread use is out of scope without the `Arc` redesign declined in #281.
